### PR TITLE
Fix for esbuild changes in nodejsfunction

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,7 +41,7 @@ export class SesSmtpCredentialsProvider extends cdk.Construct {
                         ],
                     }),
                 ],
-            }),
+            } as lambdaNodejs.NodejsFunctionProps),
         });
     }
 }


### PR DESCRIPTION
CDK changed to remove `projectRoot`, see https://github.com/aws/aws-cdk/blob/master/CHANGELOG.md#1750-2020-11-24

This was the only way I could think of to paper over that crack. Perhaps there is a more elegant way, but I couldn't think of it.