### PR TITLE
Fix for depsLockFilePath

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ export class SesSmtpCredentialsProvider extends cdk.Construct {
             onEventHandler: new lambdaNodejs.NodejsFunction(this, 'ses-smtp-credentials-event', {
                 entry: path.join(__dirname, 'provider', 'main.ts'),
                 projectRoot: path.join(__dirname, 'provider'),
+                depsLockFilePath: path.join(__dirname, 'provider', 'package-lock.json'),
                 runtime: lambda.Runtime.NODEJS_12_X,
                 // To handle parcel-based versions of NodejsFunction
                 nodeModules: [


### PR DESCRIPTION
I think this is a fix akin to https://github.com/aws/aws-cdk/issues/12115#issuecomment-746969934.

I had been hitting errors like:
```
Error: Expected depsLockFilePath: /home/me/myproject/package-lock.json to be under projectRoot: /home/me/myproject/node_modules/ses-smtp-credentials-cdk/provider (../../../package-lock.json)
```
That is, it is hunting for the package-lock up the tree and finding it in my main project, not the one in `./provider` for this dependency.