### PR TITLE
Explicitly include aws-sdk in external modules

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,11 +27,13 @@ export class SesSmtpCredentialsProvider extends cdk.Construct {
                 // To handle parcel-based versions of NodejsFunction
                 nodeModules: [
                     'utf8',
+                    'aws-sdk',
                 ],
                 // To handle esbuild-based versions of NodejsFunction
                 bundling: {
                     externalModules: [
                         'utf8',
+                        'aws-sdk',
                     ],
                 },
                 handler: 'onEvent',


### PR DESCRIPTION
This is the default, but we manually override it. We should retain `aws-sdk` in the list.