### PR TITLE
Remove deprecated "main" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "ses-smtp-credentials-cdk",
   "version": "2.0.0",
   "description": "Create SMTP Credentials for use with SES",
-  "main": "lib/index.js",
   "scripts": {
     "compile": "tsc",
     "clean": "rm -rf ./lib",


### PR DESCRIPTION
To remove warnings like:
```
[DEP0128] DeprecationWarning: Invalid 'main' field in '/.../node_modules/ses-smtp-credentials-cdk/package.json' of 'lib/index.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```