### PR TITLE
Remove vulnerable CDK v1 dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "3.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@aws-cdk/aws-lambda": "^1.89.0",
-        "@aws-cdk/core": "^1.89.0",
-        "@aws-cdk/custom-resources": "^1.89.0",
         "@types/node": "^18.19.33",
         "@typescript-eslint/eslint-plugin": "4.8.2",
         "@typescript-eslint/parser": "4.8.2",
@@ -27,11 +24,6 @@
         "utf8": "^3.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudformation": "^1.89.0",
-        "@aws-cdk/aws-iam": "^1.89.0",
-        "@aws-cdk/aws-lambda": "^1.89.0",
-        "@aws-cdk/core": "^1.89.0",
-        "@aws-cdk/custom-resources": "^1.89.0",
         "aws-cdk-lib": "^2.51.0",
         "constructs": "^10.0.0"
       },
@@ -76,1045 +68,6 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
       "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==",
       "dev": true
-    },
-    "node_modules/@aws-cdk/assets": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.174.0.tgz",
-      "integrity": "sha512-VtVjEtsnw3esecSuW3qeuOxhYdYDIhTJYXUZzCdpoXj4v3FAukdsUKC0CPhDblAU8CbcUMhCTGPcKb7dW35VyA==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/assets/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-applicationautoscaling": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.174.0.tgz",
-      "integrity": "sha512-CyVtGTcnVTf6NNbfqRoyhh8YxiiAGURZY3qI1ik3dcH8SQNd61sn7qw1hbcp8scKYrPjw6G7HTQEoe3wucXtlg==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-autoscaling-common": "1.174.0",
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-autoscaling-common": "1.174.0",
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-applicationautoscaling/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-autoscaling-common": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.174.0.tgz",
-      "integrity": "sha512-ZcnCYVXa4Qb5uHULSsVKzlFJu59bq0pzNS4JbaYdq1O7sT7ixhp6yb9fdD8Pq1goKEqdpsePBrMlzKKdhqZxXw==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-autoscaling-common/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-cloudformation": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.174.0.tgz",
-      "integrity": "sha512-s74tP4QaqYd7yscajlhkd+3UZxx67nIGSCZ0IecvbbhydIxEhMr2TxsjxSDkQkf8h6oKoF9gFxExJ+0OsZv6TA==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-lambda": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-lambda": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-cloudformation/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-cloudwatch": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.174.0.tgz",
-      "integrity": "sha512-YqCYZsy/qc7faHWPhYSJMjPnBmm1sr5p6YzvA4Aq3UJLQeJlYOHNU2Wl98Yje9ajFN0svsD27n8rcmP4HqLCuQ==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-cloudwatch/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-codeguruprofiler": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.174.0.tgz",
-      "integrity": "sha512-5u5x2dTUDBTOYqR2aQksZdxLxATH8pKet5HJOoBXe/hG3PzZJEmKMqmHKEULa79T+/4UNgxQebEtWeX7JPpqEQ==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-codeguruprofiler/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-codestarnotifications": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.174.0.tgz",
-      "integrity": "sha512-bnicTK7KsEmQ7FqP7OgspATeMObMoqVAS8q5r4kioeDjp8tw1hHMAHe+7wQR6ucFwIR0f3oFzzRffimy8yghkw==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-codestarnotifications/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ec2": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.174.0.tgz",
-      "integrity": "sha512-ORYaNa11N2g8ryGLsIVT2ukeJ13z094gQITCdd+BL+kPvqXmrgG8k452qUskS9w07WCMb9jRUct9KmmgR+wLfw==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/aws-ssm": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/aws-ssm": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ec2/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ecr": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.174.0.tgz",
-      "integrity": "sha512-X85yGM8JhMU/InC+IQZWsiOrG7nDmAQRH67FmiKhOoQaT0APAw1oE03UbJNOivpvtG2G4QBHx1yU9Wf2jf8vBg==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ecr-assets": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.174.0.tgz",
-      "integrity": "sha512-UtElPaXDX6l+/guPo+b24y6En6mri32MvIakmOYJiXMzQnbigI3rAsjH+s4WBJX3kGLJ2pkahmkPy1bEmnTf7w==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/assets": "1.174.0",
-        "@aws-cdk/aws-ecr": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/assets": "1.174.0",
-        "@aws-cdk/aws-ecr": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ecr-assets/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ecr/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-efs": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.174.0.tgz",
-      "integrity": "sha512-8dWJSaabRXxQIa/3AofXvf25z/zpbu7G7M6rzB0tKt7TUYo9D0B7zMUAJjwC2xPFAsj9M6otjtP3oCgn59xYyg==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-efs/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-events": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.174.0.tgz",
-      "integrity": "sha512-AI4570quw4HQ8Hs0jHxWM366yBYkfO0783jsdXbT+xi4FfTTB8rn/AqXRew2E6Kmycz4nu98dNxkoVu5HGX8ZQ==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-events/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-iam": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.174.0.tgz",
-      "integrity": "sha512-4IDN29ABEmF8Wk/rkMQTva6mB80QdKyNRHzV5O5sZ8s/PbxAXmewtDTnF5nt/cDJxfBhyMc3Ol3B1fOxjXFV+A==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-iam/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-kms": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.174.0.tgz",
-      "integrity": "sha512-CXbk9rWi7MhDBT7kWip2Q6xCO/wG4p19EGi4kJwZA4v2/uPDltGmiJT5nLapGV5Y5wOpR9jNOtxYMLqYX+0RAg==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-kms/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-lambda": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.174.0.tgz",
-      "integrity": "sha512-P+UdkDkCCfwUi7bjvyh53huxCMVD/tys6r03xZNmmdB4zsnN99xEsQSFhGa2qt4txtHyoLarPKtx3O4wRKRYXg==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-applicationautoscaling": "1.174.0",
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.174.0",
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-ecr": "1.174.0",
-        "@aws-cdk/aws-ecr-assets": "1.174.0",
-        "@aws-cdk/aws-efs": "1.174.0",
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/aws-signer": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/aws-sqs": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-applicationautoscaling": "1.174.0",
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.174.0",
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-ecr": "1.174.0",
-        "@aws-cdk/aws-ecr-assets": "1.174.0",
-        "@aws-cdk/aws-efs": "1.174.0",
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/aws-signer": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/aws-sqs": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-lambda/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-logs": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.174.0.tgz",
-      "integrity": "sha512-QzmIg/QeNFnQcj4HswxurF36riPPm58zwuULfWcStVatMm6+t10cNe64zxjKyRzP2WX9SEPaa0Z4tZlJq6lo2A==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-logs/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-s3": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.174.0.tgz",
-      "integrity": "sha512-rkXWmF5EHVJvtvWby0Dy48lPQVhBMBMFmoR+opfQrDmUh9XsPDGfmhrbKFWUMvsO43609zutFfrJFYgJfV8cNA==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-s3-assets": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.174.0.tgz",
-      "integrity": "sha512-xoUR83qbDoycR5RRA4jJrEevh3LCpsygPu3WyEJ1zA3Kmi9UKb0gQx6/GDrmqASBCGhkvaParQFee9V7slEgaw==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/assets": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/assets": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-s3-assets/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-s3/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-signer": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.174.0.tgz",
-      "integrity": "sha512-+Gc0lxTa2sOCxZcMp3SskX+bp1LiL8mf6tw9Aaoz+yeupnArAmxEH3ke9pJRhVfJuYQkNZETj41LpGm/E+O0LQ==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-signer/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-sns": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.174.0.tgz",
-      "integrity": "sha512-JY3ZxbFSNrVm2Lz+6dBLk5lqk1d2pTx9C8JxIBttq3TLGD0WXj3nKm6jfPy9m6UHn5FA7UOKKVpmr9NvpFy/0Q==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-codestarnotifications": "1.174.0",
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-sqs": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-codestarnotifications": "1.174.0",
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-sqs": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-sns/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-sqs": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.174.0.tgz",
-      "integrity": "sha512-vFrSjROhz0QemqQ8QN88SrtDCeUyz2Xrup4RkGvcqshCKRH6t+KtcMn8URng15M5H5CGW7jmPhLpKEYw8RlD+w==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-sqs/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ssm": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.174.0.tgz",
-      "integrity": "sha512-Hni6ZeXsrUjPQXC4G9LhJF/xwgcsqRXK4e5VpqRk3J0id7RCRche9qHYrdAaLfADihbBHrrf/ELQzDp0Ud4/Eg==",
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/aws-ssm/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.174.0.tgz",
-      "integrity": "sha512-F3ZYy3RVcGGYIHCoHv6/eO3bd6GVhtzcmwEf9ky6cHaHgp7DGmzjlY3jqaHyduCLg+FXztG0jAbJhWJwbzpkCg==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "devOptional": true,
-      "dependencies": {
-        "jsonschema": "^1.4.1",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.3.7",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
-      "version": "4.0.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@aws-cdk/core": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.174.0.tgz",
-      "integrity": "sha512-AycBJIiyc5dVGo3QsDLTpPMaS8AYX0WPytd4K2lGdyWobsamOgb7gDCqx238zHe3KjqxY0v9ra9PVbyFf1VLjw==",
-      "bundleDependencies": [
-        "fs-extra",
-        "minimatch",
-        "@balena/dockerignore",
-        "ignore"
-      ],
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "@balena/dockerignore": "^1.0.2",
-        "constructs": "^3.3.69",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
-        "minimatch": "^3.1.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@aws-cdk/core/node_modules/at-least-node": {
-      "version": "1.0.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@aws-cdk/core/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/concat-map": {
-      "version": "0.0.1",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@aws-cdk/core/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@aws-cdk/core/node_modules/ignore": {
-      "version": "5.2.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/minimatch": {
-      "version": "3.1.2",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/core/node_modules/universalify": {
-      "version": "2.0.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/custom-resources": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.174.0.tgz",
-      "integrity": "sha512-aoUIKq2GShfiLLte6Q+PauR+UHqPFEUB/bDcPFpx/KzHsPp2BoGSdSHVzboZEyqw0B+SbTBD2aF1/62ubKdkhg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-cdk/aws-cloudformation": "1.174.0",
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-lambda": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-cloudformation": "1.174.0",
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-lambda": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "node_modules/@aws-cdk/custom-resources/node_modules/constructs": {
-      "version": "3.4.244",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-      "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
-    },
-    "node_modules/@aws-cdk/cx-api": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.174.0.tgz",
-      "integrity": "sha512-BbOGfNZCbGCQFc/0SCkDncvfxJUjEC46888YadrRxhWx9kq4zM2UjgJdZCMr94eExMR8kiLKwSI3OAmEQfevsA==",
-      "bundleDependencies": [
-        "semver"
-      ],
-      "devOptional": true,
-      "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.174.0"
-      }
-    },
-    "node_modules/@aws-cdk/cx-api/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@aws-cdk/cx-api/node_modules/semver": {
-      "version": "7.3.7",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@aws-cdk/cx-api/node_modules/yallist": {
-      "version": "4.0.0",
-      "devOptional": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/@aws-cdk/region-info": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.174.0.tgz",
-      "integrity": "sha512-jGpeB3mTcwzEmWKjItuGTWDUb1VpkTEg6XnXmpWrMmfzSEwRTjQy8UQNvqGA3sJRzyUm2RS2za0lpMRe0duStQ==",
-      "devOptional": true,
-      "engines": {
-        "node": ">= 14.15.0"
-      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1843,9 +796,9 @@
       }
     },
     "node_modules/auto-changelog/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2266,12 +1219,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2367,9 +1320,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -2383,9 +1336,9 @@
       }
     },
     "node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2661,9 +1614,9 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2856,9 +1809,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3274,18 +2227,6 @@
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3296,12 +2237,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3691,13 +2632,10 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4060,9 +2998,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4091,12 +3029,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     }
   },
   "dependencies": {
@@ -4117,684 +3049,6 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
       "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==",
       "dev": true
-    },
-    "@aws-cdk/assets": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.174.0.tgz",
-      "integrity": "sha512-VtVjEtsnw3esecSuW3qeuOxhYdYDIhTJYXUZzCdpoXj4v3FAukdsUKC0CPhDblAU8CbcUMhCTGPcKb7dW35VyA==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-applicationautoscaling": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.174.0.tgz",
-      "integrity": "sha512-CyVtGTcnVTf6NNbfqRoyhh8YxiiAGURZY3qI1ik3dcH8SQNd61sn7qw1hbcp8scKYrPjw6G7HTQEoe3wucXtlg==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-autoscaling-common": "1.174.0",
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-autoscaling-common": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.174.0.tgz",
-      "integrity": "sha512-ZcnCYVXa4Qb5uHULSsVKzlFJu59bq0pzNS4JbaYdq1O7sT7ixhp6yb9fdD8Pq1goKEqdpsePBrMlzKKdhqZxXw==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-cloudformation": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.174.0.tgz",
-      "integrity": "sha512-s74tP4QaqYd7yscajlhkd+3UZxx67nIGSCZ0IecvbbhydIxEhMr2TxsjxSDkQkf8h6oKoF9gFxExJ+0OsZv6TA==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-lambda": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-cloudwatch": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.174.0.tgz",
-      "integrity": "sha512-YqCYZsy/qc7faHWPhYSJMjPnBmm1sr5p6YzvA4Aq3UJLQeJlYOHNU2Wl98Yje9ajFN0svsD27n8rcmP4HqLCuQ==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-codeguruprofiler": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.174.0.tgz",
-      "integrity": "sha512-5u5x2dTUDBTOYqR2aQksZdxLxATH8pKet5HJOoBXe/hG3PzZJEmKMqmHKEULa79T+/4UNgxQebEtWeX7JPpqEQ==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-codestarnotifications": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.174.0.tgz",
-      "integrity": "sha512-bnicTK7KsEmQ7FqP7OgspATeMObMoqVAS8q5r4kioeDjp8tw1hHMAHe+7wQR6ucFwIR0f3oFzzRffimy8yghkw==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-ec2": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.174.0.tgz",
-      "integrity": "sha512-ORYaNa11N2g8ryGLsIVT2ukeJ13z094gQITCdd+BL+kPvqXmrgG8k452qUskS9w07WCMb9jRUct9KmmgR+wLfw==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/aws-ssm": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-ecr": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.174.0.tgz",
-      "integrity": "sha512-X85yGM8JhMU/InC+IQZWsiOrG7nDmAQRH67FmiKhOoQaT0APAw1oE03UbJNOivpvtG2G4QBHx1yU9Wf2jf8vBg==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-ecr-assets": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.174.0.tgz",
-      "integrity": "sha512-UtElPaXDX6l+/guPo+b24y6En6mri32MvIakmOYJiXMzQnbigI3rAsjH+s4WBJX3kGLJ2pkahmkPy1bEmnTf7w==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/assets": "1.174.0",
-        "@aws-cdk/aws-ecr": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-efs": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.174.0.tgz",
-      "integrity": "sha512-8dWJSaabRXxQIa/3AofXvf25z/zpbu7G7M6rzB0tKt7TUYo9D0B7zMUAJjwC2xPFAsj9M6otjtP3oCgn59xYyg==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-events": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.174.0.tgz",
-      "integrity": "sha512-AI4570quw4HQ8Hs0jHxWM366yBYkfO0783jsdXbT+xi4FfTTB8rn/AqXRew2E6Kmycz4nu98dNxkoVu5HGX8ZQ==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-iam": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.174.0.tgz",
-      "integrity": "sha512-4IDN29ABEmF8Wk/rkMQTva6mB80QdKyNRHzV5O5sZ8s/PbxAXmewtDTnF5nt/cDJxfBhyMc3Ol3B1fOxjXFV+A==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-kms": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.174.0.tgz",
-      "integrity": "sha512-CXbk9rWi7MhDBT7kWip2Q6xCO/wG4p19EGi4kJwZA4v2/uPDltGmiJT5nLapGV5Y5wOpR9jNOtxYMLqYX+0RAg==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-lambda": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.174.0.tgz",
-      "integrity": "sha512-P+UdkDkCCfwUi7bjvyh53huxCMVD/tys6r03xZNmmdB4zsnN99xEsQSFhGa2qt4txtHyoLarPKtx3O4wRKRYXg==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "1.174.0",
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.174.0",
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-ecr": "1.174.0",
-        "@aws-cdk/aws-ecr-assets": "1.174.0",
-        "@aws-cdk/aws-efs": "1.174.0",
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/aws-signer": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/aws-sqs": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-logs": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.174.0.tgz",
-      "integrity": "sha512-QzmIg/QeNFnQcj4HswxurF36riPPm58zwuULfWcStVatMm6+t10cNe64zxjKyRzP2WX9SEPaa0Z4tZlJq6lo2A==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-s3-assets": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-s3": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.174.0.tgz",
-      "integrity": "sha512-rkXWmF5EHVJvtvWby0Dy48lPQVhBMBMFmoR+opfQrDmUh9XsPDGfmhrbKFWUMvsO43609zutFfrJFYgJfV8cNA==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-s3-assets": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.174.0.tgz",
-      "integrity": "sha512-xoUR83qbDoycR5RRA4jJrEevh3LCpsygPu3WyEJ1zA3Kmi9UKb0gQx6/GDrmqASBCGhkvaParQFee9V7slEgaw==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/assets": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-s3": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-signer": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.174.0.tgz",
-      "integrity": "sha512-+Gc0lxTa2sOCxZcMp3SskX+bp1LiL8mf6tw9Aaoz+yeupnArAmxEH3ke9pJRhVfJuYQkNZETj41LpGm/E+O0LQ==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-sns": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.174.0.tgz",
-      "integrity": "sha512-JY3ZxbFSNrVm2Lz+6dBLk5lqk1d2pTx9C8JxIBttq3TLGD0WXj3nKm6jfPy9m6UHn5FA7UOKKVpmr9NvpFy/0Q==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-codestarnotifications": "1.174.0",
-        "@aws-cdk/aws-events": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/aws-sqs": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-sqs": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.174.0.tgz",
-      "integrity": "sha512-vFrSjROhz0QemqQ8QN88SrtDCeUyz2Xrup4RkGvcqshCKRH6t+KtcMn8URng15M5H5CGW7jmPhLpKEYw8RlD+w==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/aws-ssm": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.174.0.tgz",
-      "integrity": "sha512-Hni6ZeXsrUjPQXC4G9LhJF/xwgcsqRXK4e5VpqRk3J0id7RCRche9qHYrdAaLfADihbBHrrf/ELQzDp0Ud4/Eg==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-kms": "1.174.0",
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/cloud-assembly-schema": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.174.0.tgz",
-      "integrity": "sha512-F3ZYy3RVcGGYIHCoHv6/eO3bd6GVhtzcmwEf9ky6cHaHgp7DGmzjlY3jqaHyduCLg+FXztG0jAbJhWJwbzpkCg==",
-      "devOptional": true,
-      "requires": {
-        "jsonschema": "^1.4.1",
-        "semver": "^7.3.7"
-      },
-      "dependencies": {
-        "jsonschema": {
-          "version": "1.4.1",
-          "bundled": true,
-          "devOptional": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true,
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/core": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.174.0.tgz",
-      "integrity": "sha512-AycBJIiyc5dVGo3QsDLTpPMaS8AYX0WPytd4K2lGdyWobsamOgb7gDCqx238zHe3KjqxY0v9ra9PVbyFf1VLjw==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "@aws-cdk/cx-api": "1.174.0",
-        "@aws-cdk/region-info": "1.174.0",
-        "@balena/dockerignore": "^1.0.2",
-        "constructs": "^3.3.69",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
-        "minimatch": "^3.1.2"
-      },
-      "dependencies": {
-        "@balena/dockerignore": {
-          "version": "1.0.2",
-          "bundled": true,
-          "devOptional": true
-        },
-        "at-least-node": {
-          "version": "1.0.0",
-          "bundled": true,
-          "devOptional": true
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "bundled": true,
-          "devOptional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "devOptional": true
-        },
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "devOptional": true
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.10",
-          "bundled": true,
-          "devOptional": true
-        },
-        "ignore": {
-          "version": "5.2.0",
-          "bundled": true,
-          "devOptional": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "bundled": true,
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/custom-resources": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.174.0.tgz",
-      "integrity": "sha512-aoUIKq2GShfiLLte6Q+PauR+UHqPFEUB/bDcPFpx/KzHsPp2BoGSdSHVzboZEyqw0B+SbTBD2aF1/62ubKdkhg==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-cloudformation": "1.174.0",
-        "@aws-cdk/aws-ec2": "1.174.0",
-        "@aws-cdk/aws-iam": "1.174.0",
-        "@aws-cdk/aws-lambda": "1.174.0",
-        "@aws-cdk/aws-logs": "1.174.0",
-        "@aws-cdk/aws-sns": "1.174.0",
-        "@aws-cdk/core": "1.174.0",
-        "constructs": "^3.3.69"
-      },
-      "dependencies": {
-        "constructs": {
-          "version": "3.4.244",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.4.244.tgz",
-          "integrity": "sha512-nGakXYkubqBTCaC9RJXWrs1crQFU7Wft8l44Wp/AM9yS6Nn1trdeGX3BatR2iBex3jspBNWhDkFnwxyme7YFmA==",
-          "dev": true
-        }
-      }
-    },
-    "@aws-cdk/cx-api": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.174.0.tgz",
-      "integrity": "sha512-BbOGfNZCbGCQFc/0SCkDncvfxJUjEC46888YadrRxhWx9kq4zM2UjgJdZCMr94eExMR8kiLKwSI3OAmEQfevsA==",
-      "devOptional": true,
-      "requires": {
-        "@aws-cdk/cloud-assembly-schema": "1.174.0",
-        "semver": "^7.3.7"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "bundled": true,
-          "devOptional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true,
-          "devOptional": true
-        }
-      }
-    },
-    "@aws-cdk/region-info": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.174.0.tgz",
-      "integrity": "sha512-jGpeB3mTcwzEmWKjItuGTWDUb1VpkTEg6XnXmpWrMmfzSEwRTjQy8UQNvqGA3sJRzyUm2RS2za0lpMRe0duStQ==",
-      "devOptional": true
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -5193,9 +3447,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -5481,12 +3735,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "callsites": {
@@ -5561,9 +3815,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
@@ -5574,9 +3828,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -5729,9 +3983,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -5934,9 +4188,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -6253,15 +4507,6 @@
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6269,12 +4514,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -6531,13 +4776,10 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -6820,9 +5062,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wordwrap": {
@@ -6845,12 +5087,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,6 @@
   },
   "homepage": "https://github.com/isotoma/ses-smtp-credentials-cdk#readme",
   "peerDependencies": {
-    "@aws-cdk/aws-cloudformation": "^1.89.0",
-    "@aws-cdk/aws-iam": "^1.89.0",
-    "@aws-cdk/aws-lambda": "^1.89.0",
-    "@aws-cdk/core": "^1.89.0",
-    "@aws-cdk/custom-resources": "^1.89.0",
     "aws-cdk-lib": "^2.51.0",
     "constructs": "^10.0.0"
   },
@@ -55,9 +50,6 @@
     }
   },
   "devDependencies": {
-    "@aws-cdk/aws-lambda": "^1.89.0",
-    "@aws-cdk/core": "^1.89.0",
-    "@aws-cdk/custom-resources": "^1.89.0",
     "@types/node": "^18.19.33",
     "@typescript-eslint/eslint-plugin": "4.8.2",
     "@typescript-eslint/parser": "4.8.2",


### PR DESCRIPTION
CDK v1 support has been dropped, so removing v1 deps that are getting bundled with vulnerable versions of semver